### PR TITLE
Added more options to start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,12 +3,12 @@
 NIC="virtio"
 QEMUSYS="qemu-system-x86_64"
 IMG=""
-RAM="1024"
+RAM="1024M"
 
 # support more options
 # modified version of https://gist.github.com/adamhotep/895cebf290e95e613c006afbffef09d7
 usage() {
-    echo "start.sh [--pcnet] [--32bqemu] [--image imagename] [-m memoryForSystemInMB]"
+    echo "start.sh [--pcnet] [--qemu-bin qemuSystemBinary] [--image imagename] [-m memoryForSystem]"
     exit
 }
 
@@ -22,18 +22,18 @@ do
     case "$arg" in
        --help)    set -- "$@" -h ;;
        --pcnet)   set -- "$@" -p ;;
-       --32bqemu) set -- "$@" -b ;;
+       --qemu-bin) set -- "$@" -b ;;
        --image)   set -- "$@" -i ;;
        # pass through anything else
        *)         set -- "$@" "$arg" ;;
     esac
 done
 # now we can process with getopt
-while getopts ":hpbi:m:" opt; do
+while getopts ":hpb:i:m:" opt; do
     case $opt in
         h)  usage ;;
         p) NIC="pcnet" ;;
-        b) QEMUSYS="qemu-system-i386" ;;
+        b) QEMUSYS=$OPTARG ;;
         i) IMG=$OPTARG ;;
         m) RAM=$OPTARG ;;
         \?) usage ;;
@@ -68,6 +68,6 @@ $QEMUSYS -enable-kvm \
     $CDIMAGE \
     -net nic,model=$NIC \
     -net user \
-    -m "$RAM"M \
+    -m "$RAM" \
     -monitor stdio \
     -snapshot -no-shutdown


### PR DESCRIPTION
The VMs supplied by modern.ie are currently 32b systems.  I was
having issues running these with the packaged version of
qemu-system-x86_64 on my distro (Ubuntu 16.04) and wanted to be
able to have a flag to use qemu-system-i386.  In doing so, I
also added a few more options that made start.sh more flexible.

--32bqemu
        use qemu-system-i386

-m
        RAM for system in MB

--pcnet
        Use pcnet network adaptor.

--image imagename
        use imagename for qemu-system

--help/-?
        A (probably excessively) terse help output.

This patch does admittedly break the current "just pass an image
name" on the command line.  I don't know how to reconcile that.